### PR TITLE
CoordinateSharp Efficiency Update

### DIFF
--- a/dcs-dtc/Models/AH64/AH64Configuration.cs
+++ b/dcs-dtc/Models/AH64/AH64Configuration.cs
@@ -103,7 +103,7 @@ namespace DTC.Models.AH64
                 var dLon = double.Parse(lon.Replace('.', ','));
 
                 float.TryParse(pos.Element("Altitude")?.Value.Replace('.', ','), out var elevation);
-                var coord = new Coordinate(dLat, dLon);
+                var coord = new Coordinate(dLat, dLon, new EagerLoad(false));
                 lat = $"{(dLat > 0 ? 'N' : 'S')} {coord.Latitude.Degrees:00}.{coord.Latitude.DecimalMinute:00.000}";
                 lon = $"{(dLon > 0 ? 'E' : 'W')} {Math.Abs(coord.Longitude.Degrees):000}.{coord.Longitude.DecimalMinute:00.000}";
 

--- a/dcs-dtc/Models/FA18/FA18Configuration.cs
+++ b/dcs-dtc/Models/FA18/FA18Configuration.cs
@@ -138,7 +138,7 @@ namespace DTC.Models.FA18
                 //    continue;
                 //}
                 float.TryParse(pos.Element("Altitude")?.Value.Replace('.', ','), out var elevation);
-                var coord = new Coordinate(dLat, dLon);
+                var coord = new Coordinate(dLat, dLon, new EagerLoad(false));
                 lat = $"{(dLat > 0 ? 'N' : 'S')} {coord.Latitude.Degrees:00}.{coord.Latitude.DecimalMinute:00.000}";
                 lon = $"{(dLon > 0 ? 'E' : 'W')} {Math.Abs(coord.Longitude.Degrees):000}.{coord.Longitude.DecimalMinute:00.000}";
 


### PR DESCRIPTION
It appears you are only using CoordinateSharp to execute lat/long string formatting. As such you can turn `EagerLoading` off which will greatly increase efficiency as it will no longer calculate information you do not need such as MGRS, Sunset, etc...

I didn't see any CoordinateSharp bindings in the UI so this should be safe to do as long as you are only needing lat/long data.

https://coordinatesharp.com/Performance

Happy Flying!