### PR TITLE
Feature f18 precise

### DIFF
--- a/dcs-dtc/DCS/DCSDTC/f18Functions.lua
+++ b/dcs-dtc/DCS/DCSDTC/f18Functions.lua
@@ -124,6 +124,10 @@ function DTC_FA18C_CheckCondition_IsPreciseNotSelected()
 	return false
 end
 
+function DTC_FA18C_CheckCondition_IsPreciseSelected()
+	return not DTC_FA18C_CheckCondition_IsPreciseNotSelected()
+end
+
 function DTC_FA18C_CheckCondition_IsLatLongNotDecimal()
 	local table = DTC_FA18C_GetRightDDI();
 	local str = table["_1__id:17"] or ""

--- a/dcs-dtc/DTC.csproj
+++ b/dcs-dtc/DTC.csproj
@@ -7,7 +7,7 @@
 		<Nullable>enable</Nullable>
 		<UseWindowsForms>true</UseWindowsForms>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>5.3.3</Version>
+		<Version>5.4.1</Version>
 		<Product>DTC for DCS</Product>
 		<Description>$(Product)</Description>
 		<ApplicationIcon>Resources\Iconleak-Atrous-Disk.ico</ApplicationIcon>

--- a/dcs-dtc/DTC.csproj
+++ b/dcs-dtc/DTC.csproj
@@ -7,7 +7,7 @@
 		<Nullable>enable</Nullable>
 		<UseWindowsForms>true</UseWindowsForms>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>5.4.1</Version>
+		<Version>5.4.2</Version>
 		<Product>DTC for DCS</Product>
 		<Description>$(Product)</Description>
 		<ApplicationIcon>Resources\Iconleak-Atrous-Disk.ico</ApplicationIcon>

--- a/dcs-dtc/Models/FA18/FA18Configuration.cs
+++ b/dcs-dtc/Models/FA18/FA18Configuration.cs
@@ -47,29 +47,7 @@ namespace DTC.Models.FA18
             }
         }
 
-        public void AfterLoadFromJson()
-        {
-            FixWaypointCoordinateFormat();
-        }
-
-        private void FixWaypointCoordinateFormat()
-        {
-            if (this.Waypoints == null) return;
-
-            foreach (var wpt in this.Waypoints.Waypoints)
-            {
-                if (!wpt.Latitude.Contains("°"))
-                {
-                    var parts = wpt.Latitude.Split('.');
-                    wpt.Latitude = $"{parts[0]}°{parts[1]}.{parts[2]}’";
-                }
-                if (!wpt.Longitude.Contains("°"))
-                {
-                    var parts = wpt.Longitude.Split('.');
-                    wpt.Longitude = $"{parts[0]}°{parts[1]}.{parts[2]}’";
-                }
-            }
-        }
+        public void AfterLoadFromJson() { }
 
         public static FA18Configuration FromCompressedString(string s)
         {

--- a/dcs-dtc/Models/FA18/Waypoints/Waypoint.cs
+++ b/dcs-dtc/Models/FA18/Waypoints/Waypoint.cs
@@ -1,10 +1,15 @@
 ﻿using DTC.Utilities;
+using System.Text.RegularExpressions;
 
 namespace DTC.Models.FA18.Waypoints
 {
     public class Waypoint
     {
-        public int Sequence { get; set; }
+        public static Regex CoordinateRegex { get; private set; } = Coordinate.DegreesMinutesTenThousandthsRegex;
+		public static CoordinateFormat CoordinateFormat { get; private set; } = CoordinateFormat.DegreesMinutesTenThousandths;
+		public static string CoordinateMask { get; private set; } = Coordinate.DegreesMinutesTenThousandthsMask;
+
+		public int Sequence { get; set; }
         public string Name { get; set; }
         public string Latitude { get; set; }
         public string Longitude { get; set; }
@@ -43,7 +48,7 @@ namespace DTC.Models.FA18.Waypoints
 
         public void SetCoordinate(string coord)
         {
-            var match = Coordinate.DegreesMinutesHundredthsRegex.Match(coord);
+            var match = CoordinateRegex.Match(coord);
             Latitude = match.Groups[1].Value;
             Longitude = match.Groups[2].Value;
         }
@@ -56,7 +61,7 @@ namespace DTC.Models.FA18.Waypoints
 
         public static bool IsCoordinateValid(string coord)
         {
-            var match = Coordinate.DegreesMinutesHundredthsRegex.Match(coord);
+            var match = CoordinateRegex.Match(coord);
             return match.Success;
         }
     }

--- a/dcs-dtc/Models/FA18/Waypoints/Waypoint.cs
+++ b/dcs-dtc/Models/FA18/Waypoints/Waypoint.cs
@@ -1,68 +1,65 @@
 ﻿using DTC.Utilities;
+using System.Drawing;
 using System.Text.RegularExpressions;
 
 namespace DTC.Models.FA18.Waypoints
 {
-    public class Waypoint
-    {
-        public static Regex CoordinateRegex { get; private set; } = Coordinate.DegreesMinutesTenThousandthsRegex;
-		public static CoordinateFormat CoordinateFormat { get; private set; } = CoordinateFormat.DegreesMinutesTenThousandths;
-		public static string CoordinateMask { get; private set; } = Coordinate.DegreesMinutesTenThousandthsMask;
-
+	public class Waypoint
+	{
 		public int Sequence { get; set; }
-        public string Name { get; set; }
-        public string Latitude { get; set; }
-        public string Longitude { get; set; }
-        public int Elevation { get; set; }
+		public string Name { get; set; }
+		public string Latitude { get; set; }
+		public string Longitude { get; set; }
+		public int Elevation { get; set; }
 
-        public Waypoint(int seq)
-        {
-            Sequence = seq;
-        }
+		public Waypoint(int seq)
+		{
+			Sequence = seq;
+		}
 
-        public void AutoName()
-        {
-            Name = "WPT " + Sequence.ToString("00");
-        }
+		public void AutoName()
+		{
+			Name = "WPT " + Sequence.ToString("00");
+		}
 
-        public bool Blank
-        {
-            get
-            {
-                var tmp = Latitude.Replace("N", "").Replace("S", "").Replace(".", "");
-                if (int.TryParse(tmp, out int latInt))
-                {
-                    if (latInt == 0)
-                    {
-                        return true;
-                    }
-                }
-                return false;
-            }
-        }
+		public bool Blank
+		{
+			get
+			{
+				CoordinateSharp.Coordinate? coordinate = GetCoordinate();
+				return coordinate is not null;
+			}
+		}
 
-        public string GetCoordinate()
-        {
-            return Latitude + " " + Longitude;
-        }
+		public CoordinateSharp.Coordinate? GetCoordinate()
+		{
+			return ToolsCoordinateSharp.FromString(Latitude + " " + Longitude);
+		}
 
-        public void SetCoordinate(string coord)
-        {
-            var match = CoordinateRegex.Match(coord);
-            Latitude = match.Groups[1].Value;
-            Longitude = match.Groups[2].Value;
-        }
+		public void SetCoordinate(CoordinateSharp.Coordinate? coordinate)
+		{
+			Latitude = Longitude = string.Empty;
 
-        public void SetCoordinate((string, string) latlon)
-        {
-            Latitude = latlon.Item1;
-            Longitude = latlon.Item2;
-        }
+			if (coordinate is not null)
+			{
+				Latitude = coordinate.Latitude.ToString(ToolsCoordinateSharp.CfoDdm);
+				Longitude = coordinate.Longitude.ToString(ToolsCoordinateSharp.CfoDdm);
+			}
+		}
 
-        public static bool IsCoordinateValid(string coord)
-        {
-            var match = CoordinateRegex.Match(coord);
-            return match.Success;
-        }
-    }
+		public void SetCoordinate(string coord)
+		{
+			SetCoordinate (ToolsCoordinateSharp.FromString(coord));
+		}
+
+		public void SetCoordinate((string, string) latlon)
+		{
+			SetCoordinate(latlon.Item1 + " " + latlon.Item2);
+		}
+
+		public static string ToStringCoordinate(CoordinateSharp.Coordinate? c)
+		{
+			return ToolsCoordinateSharp.ToStringDDM(c);
+		}
+	}
 }

--- a/dcs-dtc/Program.cs
+++ b/dcs-dtc/Program.cs
@@ -1,4 +1,5 @@
 ﻿using DTC.UI;
+using System.Globalization;
 
 namespace DTC;
 
@@ -12,6 +13,17 @@ static class Program
     {
         Application.EnableVisualStyles();
         Application.SetCompatibleTextRenderingDefault(false);
-        Application.Run(new MainForm());
+		InitializeCulture();
+
+		Application.Run(new MainForm());
     }
+
+	private static void InitializeCulture()
+	{
+		CultureInfo cultureInfo = CultureInfo.InvariantCulture;
+		//CultureInfo cultureInfo = new CultureInfo("fr-FR");
+		CultureInfo.DefaultThreadCurrentCulture = cultureInfo;
+		Thread.CurrentThread.CurrentCulture = cultureInfo;
+	}
+
 }

--- a/dcs-dtc/UI/Aircrafts/FA18/FA18Page.cs
+++ b/dcs-dtc/UI/Aircrafts/FA18/FA18Page.cs
@@ -44,7 +44,7 @@ namespace DTC.UI.Aircrafts.FA18
             {
                 var coord = Coordinate.FromString(d.latitude, d.longitude, CoordinateFormat.NativeDCSFormat);
                 var wpt = new Waypoint(0);
-                wpt.SetCoordinate(coord.ToDegreesMinutesHundredths());
+                wpt.SetCoordinate(coord.InternalCoordinateSharp);
                 wpt.Elevation = int.Parse(d.elevation);
                 newWptList.Add(wpt);
             }

--- a/dcs-dtc/UI/Aircrafts/FA18/WaypointEdit.Designer.cs
+++ b/dcs-dtc/UI/Aircrafts/FA18/WaypointEdit.Designer.cs
@@ -45,6 +45,9 @@ namespace DTC.UI.Aircrafts.FA18
 			label1 = new Label();
 			label2 = new Label();
 			lblValidation = new Label();
+			TbCoordinates = new TextBox();
+			LbCoordinatesDetail = new Label();
+			LbCoordinatesFrame = new Label();
 			pnlTop.SuspendLayout();
 			SuspendLayout();
 			// 
@@ -117,7 +120,7 @@ namespace DTC.UI.Aircrafts.FA18
 			btnSave.FlatAppearance.BorderSize = 0;
 			btnSave.FlatStyle = FlatStyle.Flat;
 			btnSave.Font = new Font("Microsoft Sans Serif", 10F, FontStyle.Regular, GraphicsUnit.Point);
-			btnSave.Location = new Point(429, 197);
+			btnSave.Location = new Point(429, 242);
 			btnSave.Name = "btnSave";
 			btnSave.Size = new Size(120, 25);
 			btnSave.TabIndex = 16;
@@ -170,7 +173,7 @@ namespace DTC.UI.Aircrafts.FA18
 			txtWptElevation.BackColor = SystemColors.Window;
 			txtWptElevation.HidePromptOnLeave = false;
 			txtWptElevation.InsertKeyMode = InsertKeyMode.Default;
-			txtWptElevation.Location = new Point(152, 138);
+			txtWptElevation.Location = new Point(152, 190);
 			txtWptElevation.Mask = "";
 			txtWptElevation.Name = "txtWptElevation";
 			txtWptElevation.PromptChar = '_';
@@ -182,15 +185,16 @@ namespace DTC.UI.Aircrafts.FA18
 			// 
 			txtWptLatLong.AllowPromptAsInput = false;
 			txtWptLatLong.BackColor = SystemColors.Window;
-			txtWptLatLong.Format = Utilities.CoordinateFormat.DegreesMinutesTenThousandths;
+			txtWptLatLong.Format = Utilities.CoordinateFormat.DegreesMinutesHundredths;
 			txtWptLatLong.HidePromptOnLeave = false;
 			txtWptLatLong.InsertKeyMode = InsertKeyMode.Default;
-			txtWptLatLong.Location = new Point(152, 104);
+			txtWptLatLong.Location = new Point(138, 245);
 			txtWptLatLong.Name = "txtWptLatLong";
 			txtWptLatLong.PromptChar = '_';
 			txtWptLatLong.Size = new Size(270, 28);
 			txtWptLatLong.TabIndex = 12;
 			txtWptLatLong.ValidatingType = null;
+			txtWptLatLong.Visible = false;
 			// 
 			// label1
 			// 
@@ -201,13 +205,13 @@ namespace DTC.UI.Aircrafts.FA18
 			label1.Padding = new Padding(5, 0, 0, 0);
 			label1.Size = new Size(150, 25);
 			label1.TabIndex = 26;
-			label1.Text = "Lat/Long:";
+			label1.Text = "Coordinates:";
 			label1.TextAlign = ContentAlignment.MiddleLeft;
 			// 
 			// label2
 			// 
 			label2.Font = new Font("Microsoft Sans Serif", 10F, FontStyle.Regular, GraphicsUnit.Point);
-			label2.Location = new Point(1, 138);
+			label2.Location = new Point(1, 190);
 			label2.Margin = new Padding(0);
 			label2.Name = "label2";
 			label2.Padding = new Padding(5, 0, 0, 0);
@@ -220,7 +224,7 @@ namespace DTC.UI.Aircrafts.FA18
 			// 
 			lblValidation.Font = new Font("Microsoft Sans Serif", 10F, FontStyle.Regular, GraphicsUnit.Point);
 			lblValidation.ForeColor = Color.Red;
-			lblValidation.Location = new Point(1, 169);
+			lblValidation.Location = new Point(1, 216);
 			lblValidation.Margin = new Padding(0);
 			lblValidation.Name = "lblValidation";
 			lblValidation.Padding = new Padding(5, 0, 0, 0);
@@ -228,12 +232,50 @@ namespace DTC.UI.Aircrafts.FA18
 			lblValidation.TabIndex = 28;
 			lblValidation.TextAlign = ContentAlignment.MiddleLeft;
 			// 
+			// TbCoordinates
+			// 
+			TbCoordinates.BorderStyle = BorderStyle.None;
+			TbCoordinates.Font = new Font("Microsoft Sans Serif", 9.75F, FontStyle.Regular, GraphicsUnit.Point);
+			TbCoordinates.Location = new Point(157, 108);
+			TbCoordinates.Name = "TbCoordinates";
+			TbCoordinates.Size = new Size(265, 15);
+			TbCoordinates.TabIndex = 29;
+			TbCoordinates.Text = "sdfsfdsf";
+			TbCoordinates.Validating += TbCoordinates_Validating;
+			// 
+			// LbCoordinatesDetail
+			// 
+			LbCoordinatesDetail.Font = new Font("Microsoft Sans Serif", 10F, FontStyle.Regular, GraphicsUnit.Point);
+			LbCoordinatesDetail.ForeColor = Color.RoyalBlue;
+			LbCoordinatesDetail.Location = new Point(152, 131);
+			LbCoordinatesDetail.Margin = new Padding(0);
+			LbCoordinatesDetail.Name = "LbCoordinatesDetail";
+			LbCoordinatesDetail.Padding = new Padding(5, 0, 0, 0);
+			LbCoordinatesDetail.Size = new Size(270, 54);
+			LbCoordinatesDetail.TabIndex = 30;
+			LbCoordinatesDetail.TextAlign = ContentAlignment.MiddleLeft;
+			// 
+			// LbCoordinatesFrame
+			// 
+			LbCoordinatesFrame.BackColor = SystemColors.Window;
+			LbCoordinatesFrame.Font = new Font("Microsoft Sans Serif", 10F, FontStyle.Regular, GraphicsUnit.Point);
+			LbCoordinatesFrame.ForeColor = Color.RoyalBlue;
+			LbCoordinatesFrame.Location = new Point(152, 104);
+			LbCoordinatesFrame.Margin = new Padding(0);
+			LbCoordinatesFrame.Name = "LbCoordinatesFrame";
+			LbCoordinatesFrame.Padding = new Padding(5, 0, 0, 0);
+			LbCoordinatesFrame.Size = new Size(272, 25);
+			LbCoordinatesFrame.TabIndex = 31;
+			LbCoordinatesFrame.TextAlign = ContentAlignment.MiddleLeft;
+			// 
 			// WaypointEdit
 			// 
 			AutoScaleDimensions = new SizeF(96F, 96F);
 			AutoScaleMode = AutoScaleMode.Dpi;
 			BackColor = Color.PaleGoldenrod;
 			BorderStyle = BorderStyle.FixedSingle;
+			Controls.Add(LbCoordinatesDetail);
+			Controls.Add(TbCoordinates);
 			Controls.Add(lblValidation);
 			Controls.Add(label2);
 			Controls.Add(label1);
@@ -246,10 +288,12 @@ namespace DTC.UI.Aircrafts.FA18
 			Controls.Add(label3);
 			Controls.Add(label5);
 			Controls.Add(pnlTop);
+			Controls.Add(LbCoordinatesFrame);
 			Name = "WaypointEdit";
-			Size = new Size(558, 231);
+			Size = new Size(558, 276);
 			pnlTop.ResumeLayout(false);
 			ResumeLayout(false);
+			PerformLayout();
 		}
 
 		#endregion
@@ -268,5 +312,8 @@ namespace DTC.UI.Aircrafts.FA18
 		private Label label1;
 		private Label label2;
 		private Label lblValidation;
+		private TextBox TbCoordinates;
+		private Label LbCoordinatesDetail;
+		private Label LbCoordinatesFrame;
 	}
 }

--- a/dcs-dtc/UI/Aircrafts/FA18/WaypointEdit.Designer.cs
+++ b/dcs-dtc/UI/Aircrafts/FA18/WaypointEdit.Designer.cs
@@ -31,243 +31,242 @@ namespace DTC.UI.Aircrafts.FA18
 		/// </summary>
 		private void InitializeComponent()
 		{
-            this.cboAirbases = new System.Windows.Forms.ComboBox();
-            this.label5 = new System.Windows.Forms.Label();
-            this.lblTitle = new System.Windows.Forms.Label();
-            this.label3 = new System.Windows.Forms.Label();
-            this.btnCapture = new System.Windows.Forms.Button();
-            this.btnSave = new DTC.UI.Base.Controls.DTCButton();
-            this.pnlTop = new System.Windows.Forms.Panel();
-            this.lblClose = new System.Windows.Forms.Label();
-            this.txtWptName = new DTC.UI.Base.Controls.DTCTextBox();
-            this.txtWptElevation = new DTC.UI.Base.Controls.DTCTextBox();
-            this.txtWptLatLong = new DTC.UI.Base.Controls.DTCCoordinateTextBox();
-            this.label1 = new System.Windows.Forms.Label();
-            this.label2 = new System.Windows.Forms.Label();
-            this.lblValidation = new System.Windows.Forms.Label();
-            this.pnlTop.SuspendLayout();
-            this.SuspendLayout();
-            // 
-            // cboAirbases
-            // 
-            this.cboAirbases.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cboAirbases.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cboAirbases.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F);
-            this.cboAirbases.FormattingEnabled = true;
-            this.cboAirbases.Location = new System.Drawing.Point(152, 36);
-            this.cboAirbases.Name = "cboAirbases";
-            this.cboAirbases.Size = new System.Drawing.Size(395, 28);
-            this.cboAirbases.TabIndex = 10;
-            this.cboAirbases.SelectedIndexChanged += new System.EventHandler(this.cboAirbases_SelectedIndexChanged);
-            // 
-            // label5
-            // 
-            this.label5.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F);
-            this.label5.Location = new System.Drawing.Point(1, 36);
-            this.label5.Margin = new System.Windows.Forms.Padding(0);
-            this.label5.Name = "label5";
-            this.label5.Padding = new System.Windows.Forms.Padding(5, 0, 0, 0);
-            this.label5.Size = new System.Drawing.Size(150, 25);
-            this.label5.TabIndex = 14;
-            this.label5.Text = "Airbases:";
-            this.label5.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // lblTitle
-            // 
-            this.lblTitle.BackColor = System.Drawing.Color.Transparent;
-            this.lblTitle.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblTitle.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold);
-            this.lblTitle.Location = new System.Drawing.Point(0, 0);
-            this.lblTitle.Name = "lblTitle";
-            this.lblTitle.Padding = new System.Windows.Forms.Padding(10, 0, 0, 0);
-            this.lblTitle.Size = new System.Drawing.Size(508, 30);
-            this.lblTitle.TabIndex = 22;
-            this.lblTitle.Text = "Add Waypoint";
-            this.lblTitle.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // label3
-            // 
-            this.label3.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F);
-            this.label3.Location = new System.Drawing.Point(1, 70);
-            this.label3.Margin = new System.Windows.Forms.Padding(0);
-            this.label3.Name = "label3";
-            this.label3.Padding = new System.Windows.Forms.Padding(5, 0, 0, 0);
-            this.label3.Size = new System.Drawing.Size(150, 25);
-            this.label3.TabIndex = 15;
-            this.label3.Text = "Waypoint Name:";
-            this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // btnCapture
-            // 
-            this.btnCapture.BackColor = System.Drawing.Color.DarkKhaki;
-            this.btnCapture.FlatAppearance.BorderSize = 0;
-            this.btnCapture.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnCapture.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F);
-            this.btnCapture.Location = new System.Drawing.Point(427, 104);
-            this.btnCapture.Name = "btnCapture";
-            this.btnCapture.Size = new System.Drawing.Size(120, 25);
-            this.btnCapture.TabIndex = 13;
-            this.btnCapture.Text = "Start Capture";
-            this.btnCapture.UseVisualStyleBackColor = false;
-            this.btnCapture.Click += new System.EventHandler(this.btnCapture_Click);
-            // 
-            // btnSave
-            // 
-            this.btnSave.BackColor = System.Drawing.Color.DarkKhaki;
-            this.btnSave.FlatAppearance.BorderSize = 0;
-            this.btnSave.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnSave.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F);
-            this.btnSave.Location = new System.Drawing.Point(429, 197);
-            this.btnSave.Name = "btnSave";
-            this.btnSave.Size = new System.Drawing.Size(120, 25);
-            this.btnSave.TabIndex = 16;
-            this.btnSave.Text = "&Save";
-            this.btnSave.UseVisualStyleBackColor = false;
-            this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
-            // 
-            // pnlTop
-            // 
-            this.pnlTop.BackColor = System.Drawing.Color.DarkKhaki;
-            this.pnlTop.Controls.Add(this.lblTitle);
-            this.pnlTop.Controls.Add(this.lblClose);
-            this.pnlTop.Dock = System.Windows.Forms.DockStyle.Top;
-            this.pnlTop.Location = new System.Drawing.Point(0, 0);
-            this.pnlTop.Name = "pnlTop";
-            this.pnlTop.Size = new System.Drawing.Size(558, 30);
-            this.pnlTop.TabIndex = 25;
-            // 
-            // lblClose
-            // 
-            this.lblClose.BackColor = System.Drawing.Color.Transparent;
-            this.lblClose.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.lblClose.Dock = System.Windows.Forms.DockStyle.Right;
-            this.lblClose.Font = new System.Drawing.Font("Calibri", 12F, System.Drawing.FontStyle.Bold);
-            this.lblClose.Location = new System.Drawing.Point(508, 0);
-            this.lblClose.Name = "lblClose";
-            this.lblClose.Size = new System.Drawing.Size(50, 30);
-            this.lblClose.TabIndex = 23;
-            this.lblClose.Text = "X";
-            this.lblClose.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            this.lblClose.Click += new System.EventHandler(this.lblClose_Click);
-            // 
-            // txtWptName
-            // 
-            this.txtWptName.AllowPromptAsInput = true;
-            this.txtWptName.BackColor = System.Drawing.SystemColors.Window;
-            this.txtWptName.HidePromptOnLeave = false;
-            this.txtWptName.InsertKeyMode = System.Windows.Forms.InsertKeyMode.Default;
-            this.txtWptName.Location = new System.Drawing.Point(152, 70);
-            this.txtWptName.Mask = "";
-            this.txtWptName.Name = "txtWptName";
-            this.txtWptName.PromptChar = '_';
-            this.txtWptName.Size = new System.Drawing.Size(395, 28);
-            this.txtWptName.TabIndex = 11;
-            this.txtWptName.ValidatingType = null;
-            // 
-            // txtWptElevation
-            // 
-            this.txtWptElevation.AllowPromptAsInput = true;
-            this.txtWptElevation.BackColor = System.Drawing.SystemColors.Window;
-            this.txtWptElevation.HidePromptOnLeave = false;
-            this.txtWptElevation.InsertKeyMode = System.Windows.Forms.InsertKeyMode.Default;
-            this.txtWptElevation.Location = new System.Drawing.Point(152, 138);
-            this.txtWptElevation.Mask = "";
-            this.txtWptElevation.Name = "txtWptElevation";
-            this.txtWptElevation.PromptChar = '_';
-            this.txtWptElevation.Size = new System.Drawing.Size(100, 28);
-            this.txtWptElevation.TabIndex = 14;
-            this.txtWptElevation.ValidatingType = null;
-            // 
-            // txtWptLatLong
-            // 
-            this.txtWptLatLong.AllowPromptAsInput = false;
-            this.txtWptLatLong.BackColor = System.Drawing.SystemColors.Window;
-            this.txtWptLatLong.HidePromptOnLeave = false;
-            this.txtWptLatLong.InsertKeyMode = System.Windows.Forms.InsertKeyMode.Default;
-            this.txtWptLatLong.Location = new System.Drawing.Point(152, 104);
-            this.txtWptLatLong.Format = DTC.Utilities.CoordinateFormat.DegreesMinutesHundredths;
-            this.txtWptLatLong.Name = "txtWptLatLong";
-            this.txtWptLatLong.PromptChar = '_';
-            this.txtWptLatLong.Size = new System.Drawing.Size(270, 28);
-            this.txtWptLatLong.TabIndex = 12;
-            this.txtWptLatLong.ValidatingType = null;
-            // 
-            // label1
-            // 
-            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F);
-            this.label1.Location = new System.Drawing.Point(1, 104);
-            this.label1.Margin = new System.Windows.Forms.Padding(0);
-            this.label1.Name = "label1";
-            this.label1.Padding = new System.Windows.Forms.Padding(5, 0, 0, 0);
-            this.label1.Size = new System.Drawing.Size(150, 25);
-            this.label1.TabIndex = 26;
-            this.label1.Text = "Lat/Long:";
-            this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // label2
-            // 
-            this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F);
-            this.label2.Location = new System.Drawing.Point(1, 138);
-            this.label2.Margin = new System.Windows.Forms.Padding(0);
-            this.label2.Name = "label2";
-            this.label2.Padding = new System.Windows.Forms.Padding(5, 0, 0, 0);
-            this.label2.Size = new System.Drawing.Size(150, 25);
-            this.label2.TabIndex = 27;
-            this.label2.Text = "Elevation:";
-            this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // lblValidation
-            // 
-            this.lblValidation.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F);
-            this.lblValidation.ForeColor = System.Drawing.Color.Red;
-            this.lblValidation.Location = new System.Drawing.Point(1, 169);
-            this.lblValidation.Margin = new System.Windows.Forms.Padding(0);
-            this.lblValidation.Name = "lblValidation";
-            this.lblValidation.Padding = new System.Windows.Forms.Padding(5, 0, 0, 0);
-            this.lblValidation.Size = new System.Drawing.Size(548, 25);
-            this.lblValidation.TabIndex = 28;
-            this.lblValidation.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // WaypointEdit
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.BackColor = System.Drawing.Color.PaleGoldenrod;
-            this.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.Controls.Add(this.lblValidation);
-            this.Controls.Add(this.label2);
-            this.Controls.Add(this.label1);
-            this.Controls.Add(this.btnSave);
-            this.Controls.Add(this.btnCapture);
-            this.Controls.Add(this.txtWptName);
-            this.Controls.Add(this.txtWptLatLong);
-            this.Controls.Add(this.txtWptElevation);
-            this.Controls.Add(this.cboAirbases);
-            this.Controls.Add(this.label3);
-            this.Controls.Add(this.label5);
-            this.Controls.Add(this.pnlTop);
-            this.Name = "WaypointEdit";
-            this.Size = new System.Drawing.Size(558, 231);
-            this.pnlTop.ResumeLayout(false);
-            this.ResumeLayout(false);
-
+			cboAirbases = new ComboBox();
+			label5 = new Label();
+			lblTitle = new Label();
+			label3 = new Label();
+			btnCapture = new Button();
+			btnSave = new DTCButton();
+			pnlTop = new Panel();
+			lblClose = new Label();
+			txtWptName = new DTCTextBox();
+			txtWptElevation = new DTCTextBox();
+			txtWptLatLong = new DTCCoordinateTextBox();
+			label1 = new Label();
+			label2 = new Label();
+			lblValidation = new Label();
+			pnlTop.SuspendLayout();
+			SuspendLayout();
+			// 
+			// cboAirbases
+			// 
+			cboAirbases.DropDownStyle = ComboBoxStyle.DropDownList;
+			cboAirbases.FlatStyle = FlatStyle.Flat;
+			cboAirbases.Font = new Font("Microsoft Sans Serif", 12F, FontStyle.Regular, GraphicsUnit.Point);
+			cboAirbases.FormattingEnabled = true;
+			cboAirbases.Location = new Point(152, 36);
+			cboAirbases.Name = "cboAirbases";
+			cboAirbases.Size = new Size(395, 28);
+			cboAirbases.TabIndex = 10;
+			cboAirbases.SelectedIndexChanged += cboAirbases_SelectedIndexChanged;
+			// 
+			// label5
+			// 
+			label5.Font = new Font("Microsoft Sans Serif", 10F, FontStyle.Regular, GraphicsUnit.Point);
+			label5.Location = new Point(1, 36);
+			label5.Margin = new Padding(0);
+			label5.Name = "label5";
+			label5.Padding = new Padding(5, 0, 0, 0);
+			label5.Size = new Size(150, 25);
+			label5.TabIndex = 14;
+			label5.Text = "Airbases:";
+			label5.TextAlign = ContentAlignment.MiddleLeft;
+			// 
+			// lblTitle
+			// 
+			lblTitle.BackColor = Color.Transparent;
+			lblTitle.Dock = DockStyle.Fill;
+			lblTitle.Font = new Font("Microsoft Sans Serif", 10F, FontStyle.Bold, GraphicsUnit.Point);
+			lblTitle.Location = new Point(0, 0);
+			lblTitle.Name = "lblTitle";
+			lblTitle.Padding = new Padding(10, 0, 0, 0);
+			lblTitle.Size = new Size(508, 30);
+			lblTitle.TabIndex = 22;
+			lblTitle.Text = "Add Waypoint";
+			lblTitle.TextAlign = ContentAlignment.MiddleLeft;
+			// 
+			// label3
+			// 
+			label3.Font = new Font("Microsoft Sans Serif", 10F, FontStyle.Regular, GraphicsUnit.Point);
+			label3.Location = new Point(1, 70);
+			label3.Margin = new Padding(0);
+			label3.Name = "label3";
+			label3.Padding = new Padding(5, 0, 0, 0);
+			label3.Size = new Size(150, 25);
+			label3.TabIndex = 15;
+			label3.Text = "Waypoint Name:";
+			label3.TextAlign = ContentAlignment.MiddleLeft;
+			// 
+			// btnCapture
+			// 
+			btnCapture.BackColor = Color.DarkKhaki;
+			btnCapture.FlatAppearance.BorderSize = 0;
+			btnCapture.FlatStyle = FlatStyle.Flat;
+			btnCapture.Font = new Font("Microsoft Sans Serif", 10F, FontStyle.Regular, GraphicsUnit.Point);
+			btnCapture.Location = new Point(427, 104);
+			btnCapture.Name = "btnCapture";
+			btnCapture.Size = new Size(120, 25);
+			btnCapture.TabIndex = 13;
+			btnCapture.Text = "Start Capture";
+			btnCapture.UseVisualStyleBackColor = false;
+			btnCapture.Click += btnCapture_Click;
+			// 
+			// btnSave
+			// 
+			btnSave.BackColor = Color.DarkKhaki;
+			btnSave.FlatAppearance.BorderSize = 0;
+			btnSave.FlatStyle = FlatStyle.Flat;
+			btnSave.Font = new Font("Microsoft Sans Serif", 10F, FontStyle.Regular, GraphicsUnit.Point);
+			btnSave.Location = new Point(429, 197);
+			btnSave.Name = "btnSave";
+			btnSave.Size = new Size(120, 25);
+			btnSave.TabIndex = 16;
+			btnSave.Text = "&Save";
+			btnSave.UseVisualStyleBackColor = false;
+			btnSave.Click += btnSave_Click;
+			// 
+			// pnlTop
+			// 
+			pnlTop.BackColor = Color.DarkKhaki;
+			pnlTop.Controls.Add(lblTitle);
+			pnlTop.Controls.Add(lblClose);
+			pnlTop.Dock = DockStyle.Top;
+			pnlTop.Location = new Point(0, 0);
+			pnlTop.Name = "pnlTop";
+			pnlTop.Size = new Size(558, 30);
+			pnlTop.TabIndex = 25;
+			// 
+			// lblClose
+			// 
+			lblClose.BackColor = Color.Transparent;
+			lblClose.Cursor = Cursors.Hand;
+			lblClose.Dock = DockStyle.Right;
+			lblClose.Font = new Font("Calibri", 12F, FontStyle.Bold, GraphicsUnit.Point);
+			lblClose.Location = new Point(508, 0);
+			lblClose.Name = "lblClose";
+			lblClose.Size = new Size(50, 30);
+			lblClose.TabIndex = 23;
+			lblClose.Text = "X";
+			lblClose.TextAlign = ContentAlignment.MiddleCenter;
+			lblClose.Click += lblClose_Click;
+			// 
+			// txtWptName
+			// 
+			txtWptName.AllowPromptAsInput = true;
+			txtWptName.BackColor = SystemColors.Window;
+			txtWptName.HidePromptOnLeave = false;
+			txtWptName.InsertKeyMode = InsertKeyMode.Default;
+			txtWptName.Location = new Point(152, 70);
+			txtWptName.Mask = "";
+			txtWptName.Name = "txtWptName";
+			txtWptName.PromptChar = '_';
+			txtWptName.Size = new Size(395, 28);
+			txtWptName.TabIndex = 11;
+			txtWptName.ValidatingType = null;
+			// 
+			// txtWptElevation
+			// 
+			txtWptElevation.AllowPromptAsInput = true;
+			txtWptElevation.BackColor = SystemColors.Window;
+			txtWptElevation.HidePromptOnLeave = false;
+			txtWptElevation.InsertKeyMode = InsertKeyMode.Default;
+			txtWptElevation.Location = new Point(152, 138);
+			txtWptElevation.Mask = "";
+			txtWptElevation.Name = "txtWptElevation";
+			txtWptElevation.PromptChar = '_';
+			txtWptElevation.Size = new Size(100, 28);
+			txtWptElevation.TabIndex = 14;
+			txtWptElevation.ValidatingType = null;
+			// 
+			// txtWptLatLong
+			// 
+			txtWptLatLong.AllowPromptAsInput = false;
+			txtWptLatLong.BackColor = SystemColors.Window;
+			txtWptLatLong.Format = Utilities.CoordinateFormat.DegreesMinutesTenThousandths;
+			txtWptLatLong.HidePromptOnLeave = false;
+			txtWptLatLong.InsertKeyMode = InsertKeyMode.Default;
+			txtWptLatLong.Location = new Point(152, 104);
+			txtWptLatLong.Name = "txtWptLatLong";
+			txtWptLatLong.PromptChar = '_';
+			txtWptLatLong.Size = new Size(270, 28);
+			txtWptLatLong.TabIndex = 12;
+			txtWptLatLong.ValidatingType = null;
+			// 
+			// label1
+			// 
+			label1.Font = new Font("Microsoft Sans Serif", 10F, FontStyle.Regular, GraphicsUnit.Point);
+			label1.Location = new Point(1, 104);
+			label1.Margin = new Padding(0);
+			label1.Name = "label1";
+			label1.Padding = new Padding(5, 0, 0, 0);
+			label1.Size = new Size(150, 25);
+			label1.TabIndex = 26;
+			label1.Text = "Lat/Long:";
+			label1.TextAlign = ContentAlignment.MiddleLeft;
+			// 
+			// label2
+			// 
+			label2.Font = new Font("Microsoft Sans Serif", 10F, FontStyle.Regular, GraphicsUnit.Point);
+			label2.Location = new Point(1, 138);
+			label2.Margin = new Padding(0);
+			label2.Name = "label2";
+			label2.Padding = new Padding(5, 0, 0, 0);
+			label2.Size = new Size(150, 25);
+			label2.TabIndex = 27;
+			label2.Text = "Elevation:";
+			label2.TextAlign = ContentAlignment.MiddleLeft;
+			// 
+			// lblValidation
+			// 
+			lblValidation.Font = new Font("Microsoft Sans Serif", 10F, FontStyle.Regular, GraphicsUnit.Point);
+			lblValidation.ForeColor = Color.Red;
+			lblValidation.Location = new Point(1, 169);
+			lblValidation.Margin = new Padding(0);
+			lblValidation.Name = "lblValidation";
+			lblValidation.Padding = new Padding(5, 0, 0, 0);
+			lblValidation.Size = new Size(548, 25);
+			lblValidation.TabIndex = 28;
+			lblValidation.TextAlign = ContentAlignment.MiddleLeft;
+			// 
+			// WaypointEdit
+			// 
+			AutoScaleDimensions = new SizeF(96F, 96F);
+			AutoScaleMode = AutoScaleMode.Dpi;
+			BackColor = Color.PaleGoldenrod;
+			BorderStyle = BorderStyle.FixedSingle;
+			Controls.Add(lblValidation);
+			Controls.Add(label2);
+			Controls.Add(label1);
+			Controls.Add(btnSave);
+			Controls.Add(btnCapture);
+			Controls.Add(txtWptName);
+			Controls.Add(txtWptLatLong);
+			Controls.Add(txtWptElevation);
+			Controls.Add(cboAirbases);
+			Controls.Add(label3);
+			Controls.Add(label5);
+			Controls.Add(pnlTop);
+			Name = "WaypointEdit";
+			Size = new Size(558, 231);
+			pnlTop.ResumeLayout(false);
+			ResumeLayout(false);
 		}
 
 		#endregion
 
-		private System.Windows.Forms.ComboBox cboAirbases;
-		private DTC.UI.Base.Controls.DTCCoordinateTextBox txtWptLatLong;
-		private System.Windows.Forms.Label label5;
-		private DTC.UI.Base.Controls.DTCTextBox txtWptName;
-		private DTC.UI.Base.Controls.DTCTextBox txtWptElevation;
-		private System.Windows.Forms.Label lblTitle;
-		private System.Windows.Forms.Panel pnlTop;
-		private System.Windows.Forms.Label lblClose;
-		private System.Windows.Forms.Button btnCapture;
-		private System.Windows.Forms.Label label3;
+		private ComboBox cboAirbases;
+		private DTCCoordinateTextBox txtWptLatLong;
+		private Label label5;
+		private DTCTextBox txtWptName;
+		private DTCTextBox txtWptElevation;
+		private Label lblTitle;
+		private Panel pnlTop;
+		private Label lblClose;
+		private Button btnCapture;
+		private Label label3;
 		private Base.Controls.DTCButton btnSave;
-		private System.Windows.Forms.Label label1;
-		private System.Windows.Forms.Label label2;
-		private System.Windows.Forms.Label lblValidation;
+		private Label label1;
+		private Label label2;
+		private Label lblValidation;
 	}
 }

--- a/dcs-dtc/UI/Aircrafts/FA18/WaypointEdit.cs
+++ b/dcs-dtc/UI/Aircrafts/FA18/WaypointEdit.cs
@@ -7,225 +7,225 @@ using System.Windows.Forms;
 
 namespace DTC.UI.Aircrafts.FA18
 {
-    public partial class WaypointEdit : UserControl
-    {
-        public enum WaypointEditResult
-        {
-            Add = 1,
-            SaveAndClose = 2,
-            Close = 3
-        }
+	public partial class WaypointEdit : UserControl
+	{
+		public enum WaypointEditResult
+		{
+			Add = 1,
+			SaveAndClose = 2,
+			Close = 3
+		}
 
-        public delegate void WaypointEditCallback(WaypointEditResult result, Waypoint wpt);
+		public delegate void WaypointEditCallback(WaypointEditResult result, Waypoint wpt);
 
-        private class AirbaseComboBoxItem
-        {
-            public string Theatre;
-            public string Airbase;
-            public string Latitude;
-            public string Longitude;
-            public int Elevation;
+		private class AirbaseComboBoxItem
+		{
+			public string Theatre;
+			public string Airbase;
+			public string Latitude;
+			public string Longitude;
+			public int Elevation;
 
-            public AirbaseComboBoxItem(string theatre, string airbase, string latitude, string longitude, int elevation)
-            {
-                Theatre = theatre;
-                Airbase = airbase;
-                Latitude = latitude;
-                Longitude = longitude;
-                Elevation = elevation;
-            }
+			public AirbaseComboBoxItem(string theatre, string airbase, string latitude, string longitude, int elevation)
+			{
+				Theatre = theatre;
+				Airbase = airbase;
+				Latitude = latitude;
+				Longitude = longitude;
+				Elevation = elevation;
+			}
 
-            public override string ToString()
-            {
-                return $"{Theatre} - {Airbase}";
-            }
-        }
+			public override string ToString()
+			{
+				return $"{Theatre} - {Airbase}";
+			}
+		}
 
-        private readonly WaypointEditCallback _callback;
-        private WaypointSystem _flightPlan;
-        private Waypoint _waypoint = null;
-        private WaypointCapture _waypointCapture;
+		private readonly WaypointEditCallback _callback;
+		private WaypointSystem _flightPlan;
+		private Waypoint _waypoint = null;
+		private WaypointCapture _waypointCapture;
 
-        public WaypointEdit(WaypointSystem flightPlan, WaypointEditCallback callback)
-        {
-            InitializeComponent();
+		public WaypointEdit(WaypointSystem flightPlan, WaypointEditCallback callback)
+		{
+			InitializeComponent();
 
-            foreach (var theater in Theater.Theaters)
-            {
-                foreach (var ab in theater.Airbases)
-                {
-                    cboAirbases.Items.Add(new AirbaseComboBoxItem(theater.Name, ab.Name, ab.Latitude, ab.Longitude, ab.Elevation));
-                }
-            }
+			foreach (var theater in Theater.Theaters)
+			{
+				foreach (var ab in theater.Airbases)
+				{
+					cboAirbases.Items.Add(new AirbaseComboBoxItem(theater.Name, ab.Name, ab.Latitude, ab.Longitude, ab.Elevation));
+				}
+			}
 
-            _callback = callback;
-            _flightPlan = flightPlan;
-        }
+			_callback = callback;
+			_flightPlan = flightPlan;
+		}
 
-        public void ShowDialog(Waypoint wpt = null)
-        {
-            this.Visible = true;
-            this.BringToFront();
-            _waypoint = wpt;
+		public void ShowDialog(Waypoint wpt = null)
+		{
+			this.Visible = true;
+			this.BringToFront();
+			_waypoint = wpt;
 
-            if (wpt != null)
-            {
-                LoadWaypoint(wpt);
-                txtWptName.Focus();
-            }
-            else
-            {
-                ResetFields();
-            }
-        }
+			if (wpt != null)
+			{
+				LoadWaypoint(wpt);
+				txtWptName.Focus();
+			}
+			else
+			{
+				ResetFields();
+			}
+		}
 
-        private void LoadWaypoint(Waypoint wpt)
-        {
-            txtWptName.Text = wpt.Name;
-            txtWptLatLong.Text = wpt.Latitude + " " + wpt.Longitude;
-            txtWptElevation.Text = wpt.Elevation.ToString();
-        }
+		private void LoadWaypoint(Waypoint wpt)
+		{
+			txtWptName.Text = wpt.Name;
+			txtWptLatLong.Text = wpt.Latitude + " " + wpt.Longitude;
+			txtWptElevation.Text = wpt.Elevation.ToString();
+		}
 
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            if (ValidateFields())
-            {
-                var wpt = new Waypoint(0);
-                wpt.Name = txtWptName.Text;
-                wpt.SetCoordinate(txtWptLatLong.Text);
-                wpt.Elevation = int.Parse(txtWptElevation.Text);
+		private void btnSave_Click(object sender, EventArgs e)
+		{
+			if (ValidateFields())
+			{
+				var wpt = new Waypoint(0);
+				wpt.Name = txtWptName.Text;
+				wpt.SetCoordinate(txtWptLatLong.Text);
+				wpt.Elevation = int.Parse(txtWptElevation.Text);
 
-                if (_waypoint == null)
-                {
-                    _flightPlan.Add(wpt);
-                    _callback(WaypointEditResult.Add, wpt);
-                    ResetFields();
-                }
-                else
-                {
-                    _waypoint.Elevation = wpt.Elevation;
-                    _waypoint.Latitude = wpt.Latitude;
-                    _waypoint.Longitude = wpt.Longitude;
-                    _waypoint.Name = wpt.Name;
-                    _callback(WaypointEditResult.SaveAndClose, _waypoint);
-                    CloseDialog();
-                }
-            }
-        }
+				if (_waypoint == null)
+				{
+					_flightPlan.Add(wpt);
+					_callback(WaypointEditResult.Add, wpt);
+					ResetFields();
+				}
+				else
+				{
+					_waypoint.Elevation = wpt.Elevation;
+					_waypoint.Latitude = wpt.Latitude;
+					_waypoint.Longitude = wpt.Longitude;
+					_waypoint.Name = wpt.Name;
+					_callback(WaypointEditResult.SaveAndClose, _waypoint);
+					CloseDialog();
+				}
+			}
+		}
 
-        private void lblClose_Click(object sender, EventArgs e)
-        {
-            _callback(WaypointEditResult.Close, null);
-            CloseDialog();
-        }
+		private void lblClose_Click(object sender, EventArgs e)
+		{
+			_callback(WaypointEditResult.Close, null);
+			CloseDialog();
+		}
 
-        private void CloseDialog()
-        {
-            _waypoint = null;
-            DisposeWptCapture();
+		private void CloseDialog()
+		{
+			_waypoint = null;
+			DisposeWptCapture();
 
-            Visible = false;
-            ResetFields();
-        }
+			Visible = false;
+			ResetFields();
+		}
 
-        private void DisposeWptCapture()
-        {
-            if (_waypointCapture != null)
-            {
-                btnCapture.Text = "Start Capture";
-                _waypointCapture.Dispose();
-                _waypointCapture = null;
-            }
-        }
+		private void DisposeWptCapture()
+		{
+			if (_waypointCapture != null)
+			{
+				btnCapture.Text = "Start Capture";
+				_waypointCapture.Dispose();
+				_waypointCapture = null;
+			}
+		}
 
-        private bool ValidateFields()
-        {
-            lblValidation.Text = "";
-            if (ValidateElevation() && ValidateLatLong() && ValidateName())
-            {
-                return true;
-            }
-            return false;
-        }
+		private bool ValidateFields()
+		{
+			lblValidation.Text = "";
+			if (ValidateElevation() && ValidateLatLong() && ValidateName())
+			{
+				return true;
+			}
+			return false;
+		}
 
-        private bool ValidateLatLong()
-        {
-            if (!txtWptLatLong.MaskFull || !Waypoint.IsCoordinateValid(txtWptLatLong.Text))
-            {
-                lblValidation.Text = "Invalid coordinate";
-                txtWptLatLong.Focus();
-                return false;
-            }
+		private bool ValidateLatLong()
+		{
+			if (!txtWptLatLong.MaskFull || !Waypoint.IsCoordinateValid(txtWptLatLong.Text))
+			{
+				lblValidation.Text = "Invalid coordinate";
+				txtWptLatLong.Focus();
+				return false;
+			}
 
-            return true;
-        }
+			return true;
+		}
 
-        private bool ValidateElevation()
-        {
-            if (!Util.IsValidInt(txtWptElevation.Text))
-            {
-                lblValidation.Text = "Invalid elevation";
-                txtWptElevation.Focus();
-                return false;
-            }
+		private bool ValidateElevation()
+		{
+			if (!Util.IsValidInt(txtWptElevation.Text))
+			{
+				lblValidation.Text = "Invalid elevation";
+				txtWptElevation.Focus();
+				return false;
+			}
 
-            return true;
-        }
+			return true;
+		}
 
-        private bool ValidateName()
-        {
-            if (txtWptName.Text == "")
-            {
-                lblValidation.Text = "Name required";
-                txtWptName.Focus();
-                return false;
-            }
+		private bool ValidateName()
+		{
+			if (txtWptName.Text == "")
+			{
+				lblValidation.Text = "Name required";
+				txtWptName.Focus();
+				return false;
+			}
 
-            return true;
-        }
+			return true;
+		}
 
-        private void ResetFields()
-        {
-            cboAirbases.SelectedIndex = -1;
-            txtWptName.Text = "WPT " + (_flightPlan.Waypoints.Count + 1).ToString();
-            txtWptLatLong.Text = "";
-            txtWptElevation.Text = "0";
-            txtWptLatLong.Focus();
-        }
+		private void ResetFields()
+		{
+			cboAirbases.SelectedIndex = -1;
+			txtWptName.Text = "WPT " + (_flightPlan.Waypoints.Count + 1).ToString();
+			txtWptLatLong.Text = "";
+			txtWptElevation.Text = "0";
+			txtWptLatLong.Focus();
+		}
 
-        private void cboAirbases_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (cboAirbases.SelectedIndex > -1)
-            {
-                var item = (AirbaseComboBoxItem)cboAirbases.SelectedItem;
-                var c = Coordinate.FromString(item.Latitude, item.Longitude, CoordinateFormat.DegreesMinutesThousandths);
-                var wpt = new Waypoint(0);
-                wpt.Name = item.Airbase;
-                wpt.SetCoordinate(c.ToDegreesMinutesHundredths());
-                wpt.Elevation = item.Elevation;
-                LoadWaypoint(wpt);
-            }
-        }
+		private void cboAirbases_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			if (cboAirbases.SelectedIndex > -1)
+			{
+				var item = (AirbaseComboBoxItem)cboAirbases.SelectedItem;
+				var c = Coordinate.FromString(item.Latitude, item.Longitude, CoordinateFormat.DegreesMinutesThousandths);
+				var wpt = new Waypoint(0);
+				wpt.Name = item.Airbase;
+				wpt.SetCoordinate(c.ToDegreesMinutesTenThousandths());
+				wpt.Elevation = item.Elevation;
+				LoadWaypoint(wpt);
+			}
+		}
 
-        private void btnCapture_Click(object sender, EventArgs e)
-        {
-            if (_waypointCapture == null)
-            {
-                btnCapture.Text = "Stop Capture";
-                _waypointCapture = new WaypointCapture((Coordinate coord, string elevation) =>
-                {
-                    this.ParentForm.Invoke(new MethodInvoker(delegate ()
-                    {
-                        var latlon = coord.ToDegreesMinutesHundredths();
-                        txtWptLatLong.Text = latlon.Item1 + " " + latlon.Item2;
-                        txtWptElevation.Text = elevation;
-                    }));
-                });
-            }
-            else
-            {
-                DisposeWptCapture();
-            }
-        }
-    }
+		private void btnCapture_Click(object sender, EventArgs e)
+		{
+			if (_waypointCapture == null)
+			{
+				btnCapture.Text = "Stop Capture";
+				_waypointCapture = new WaypointCapture((Coordinate coord, string elevation) =>
+				{
+					this.ParentForm.Invoke(new MethodInvoker(delegate ()
+					{
+						var latlon = coord.ToDegreesMinutesTenThousandths();
+						txtWptLatLong.Text = latlon.Item1 + " " + latlon.Item2;
+						txtWptElevation.Text = elevation;
+					}));
+				});
+			}
+			else
+			{
+				DisposeWptCapture();
+			}
+		}
+	}
 }

--- a/dcs-dtc/UI/Aircrafts/FA18/WaypointEdit.resx
+++ b/dcs-dtc/UI/Aircrafts/FA18/WaypointEdit.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+  <!--
     Microsoft ResX Schema 
-    
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/dcs-dtc/UI/Base/Controls/DTCCoordinateTextBox.cs
+++ b/dcs-dtc/UI/Base/Controls/DTCCoordinateTextBox.cs
@@ -22,7 +22,9 @@ namespace DTC.UI.Base.Controls
                         textBox.Mask = Coordinate.DegreesMinutesHundredthsMask; break;
                     case CoordinateFormat.DegreesMinutesThousandths:
                         textBox.Mask = Coordinate.DegreesMinutesThousandthsMask; break;
-                    case CoordinateFormat.DegreesMinutesSecondsHundredths:
+					case CoordinateFormat.DegreesMinutesTenThousandths:
+						textBox.Mask = Coordinate.DegreesMinutesTenThousandthsMask; break;
+					case CoordinateFormat.DegreesMinutesSecondsHundredths:
                         textBox.Mask = Coordinate.DegreesMinutesSecondsHundredthsMask; break;
                     default:
                         throw new Exception("Invalid format");

--- a/dcs-dtc/UI/Base/Controls/DTCCoordinateTextBox.cs
+++ b/dcs-dtc/UI/Base/Controls/DTCCoordinateTextBox.cs
@@ -22,8 +22,6 @@ namespace DTC.UI.Base.Controls
                         textBox.Mask = Coordinate.DegreesMinutesHundredthsMask; break;
                     case CoordinateFormat.DegreesMinutesThousandths:
                         textBox.Mask = Coordinate.DegreesMinutesThousandthsMask; break;
-					case CoordinateFormat.DegreesMinutesTenThousandths:
-						textBox.Mask = Coordinate.DegreesMinutesTenThousandthsMask; break;
 					case CoordinateFormat.DegreesMinutesSecondsHundredths:
                         textBox.Mask = Coordinate.DegreesMinutesSecondsHundredthsMask; break;
                     default:

--- a/dcs-dtc/Utilities/Coordinate.cs
+++ b/dcs-dtc/Utilities/Coordinate.cs
@@ -20,14 +20,14 @@ namespace DTC.Utilities
     {
         public static Regex DegreesMinutesHundredthsRegex = new Regex("^([N|S] \\d\\d\\°\\d\\d\\.\\d\\d\\’) ([E|W] \\d\\d\\d\\°\\d\\d\\.\\d\\d\\’)$");
         public static Regex DegreesMinutesThousandthsRegex = new Regex("^([N|S] \\d\\d\\°\\d\\d\\.\\d\\d\\d\\’) ([E|W] \\d\\d\\d\\°\\d\\d\\.\\d\\d\\d\\’)$");
-		public static Regex DegreesMinutesTenThousandthsRegex = new Regex("^([N|S] \\d\\d\\°\\d\\d\\.\\d\\d\\d\\d\\’) ([E|W] \\d\\d\\d\\°\\d\\d\\.\\d\\d\\d\\d\\’)$");
 
 		public static string DegreesMinutesHundredthsMask = ">L 00°00\\.00’ L 000°00\\.00’";
         public static string DegreesMinutesThousandthsMask = ">L 00°00\\.000’ L 000°00\\.000’";
-		public static string DegreesMinutesTenThousandthsMask = ">L 00°00\\.0000’ L 000°00\\.0000’";
 		public static string DegreesMinutesSecondsHundredthsMask = ">L 00°00’00\\.00” L 000°00’00\\.00”";
 
         private readonly CoordinateSharp.Coordinate c;
+        public CoordinateSharp.Coordinate InternalCoordinateSharp {  get { return c; } }
+		
         public readonly CoordinateFormat Format;
 
         public static Coordinate FromString(string lat, string lon, CoordinateFormat format)

--- a/dcs-dtc/Utilities/Coordinate.cs
+++ b/dcs-dtc/Utilities/Coordinate.cs
@@ -20,10 +20,12 @@ namespace DTC.Utilities
     {
         public static Regex DegreesMinutesHundredthsRegex = new Regex("^([N|S] \\d\\d\\°\\d\\d\\.\\d\\d\\’) ([E|W] \\d\\d\\d\\°\\d\\d\\.\\d\\d\\’)$");
         public static Regex DegreesMinutesThousandthsRegex = new Regex("^([N|S] \\d\\d\\°\\d\\d\\.\\d\\d\\d\\’) ([E|W] \\d\\d\\d\\°\\d\\d\\.\\d\\d\\d\\’)$");
-        
-        public static string DegreesMinutesHundredthsMask = ">L 00°00\\.00’ L 000°00\\.00’";
+		public static Regex DegreesMinutesTenThousandthsRegex = new Regex("^([N|S] \\d\\d\\°\\d\\d\\.\\d\\d\\d\\d\\’) ([E|W] \\d\\d\\d\\°\\d\\d\\.\\d\\d\\d\\d\\’)$");
+
+		public static string DegreesMinutesHundredthsMask = ">L 00°00\\.00’ L 000°00\\.00’";
         public static string DegreesMinutesThousandthsMask = ">L 00°00\\.000’ L 000°00\\.000’";
-        public static string DegreesMinutesSecondsHundredthsMask = ">L 00°00’00\\.00” L 000°00’00\\.00”";
+		public static string DegreesMinutesTenThousandthsMask = ">L 00°00\\.0000’ L 000°00\\.0000’";
+		public static string DegreesMinutesSecondsHundredthsMask = ">L 00°00’00\\.00” L 000°00’00\\.00”";
 
         private readonly CoordinateSharp.Coordinate c;
         public readonly CoordinateFormat Format;

--- a/dcs-dtc/Utilities/ToolsCoordinateSharp.cs
+++ b/dcs-dtc/Utilities/ToolsCoordinateSharp.cs
@@ -1,0 +1,52 @@
+﻿namespace DTC.Utilities
+{
+	internal static class ToolsCoordinateSharp
+	{
+		public static readonly CoordinateSharp.CoordinateFormatOptions CfoDms = new CoordinateSharp.CoordinateFormatOptions()
+		{
+			Format = CoordinateSharp.CoordinateFormatType.Degree_Minutes_Seconds,
+			Round = 2,
+			Display_Leading_Zeros = true,
+			Display_Trailing_Zeros = true
+		};
+		public static readonly CoordinateSharp.CoordinateFormatOptions CfoDdm = new CoordinateSharp.CoordinateFormatOptions()
+		{
+			Format = CoordinateSharp.CoordinateFormatType.Degree_Decimal_Minutes,
+			Round = 4,
+			Display_Leading_Zeros = true,
+			Display_Trailing_Zeros = true
+		};
+
+		public static CoordinateSharp.Coordinate? FromString(string s)
+		{
+			if (CoordinateSharp.Coordinate.TryParse(s, out CoordinateSharp.Coordinate coordinate))
+				return coordinate;
+			else
+				return null;
+		}
+
+		public static string ToStringDMS(CoordinateSharp.Coordinate? c)
+		{
+			if (c is not null)
+				return c.ToString(CfoDms);
+			else
+				return string.Empty;
+		}
+
+		public static string ToStringDDM(CoordinateSharp.Coordinate? c)
+		{
+			if (c is not null)
+				return c.ToString(CfoDdm);
+			else
+				return string.Empty;
+		}
+
+		public static string ToStringMGRS(CoordinateSharp.Coordinate? c)
+		{
+			if (c is not null)
+				return c.MGRS.ToString();
+			else
+				return string.Empty;
+		}
+	}
+}


### PR DESCRIPTION
**Enabling precise coordinates for F/A-18C waypoints.**
Addressing https://github.com/the-paid-actor/dcs-dtc/issues/82, and incidentally https://github.com/the-paid-actor/dcs-dtc/issues/73

### Mechanics
Upload process now checks if the jet is in _PRECISE_ and uploads coordinates accordingly. 
Note: still works for DDM mode only. As it was before, if the jet is in _DMS_ upload will not function properly.

Save file json is now agnostic. The saving will push _DDM_ precise coordinates. The loading will try to parse whatever is in the file (so it will still work with files not created with this version).

Waypoint captures (both modes) will now capture precise coordinates.

### Ergonomy
Waypoint input does not use the `DTCCoordinateTextBox` anymore. It has been replace by a standard `Textbox`. At validation the program will try to parse and whatever is input in this `Textbox `to a correct coordinate.

### Misc.
Application culture has been forced to `CultureInfo.InvariantCulture` to enforce the separators used in coordinates formatting.
This is done application wide, not only for the F/A-18C.