### PR TITLE
F16C Datalink: skip blank STN slots + related fixes

### DIFF
--- a/dcs-dtc/New/UI/Aircrafts/F16/Systems/DatalinkPage.cs
+++ b/dcs-dtc/New/UI/Aircrafts/F16/Systems/DatalinkPage.cs
@@ -41,14 +41,14 @@ namespace DTC.New.UI.Aircrafts.F16.Systems
 
             if (datalink.Members != null)
             {
-                txtSTN1.Text = datalink.Members[0] == "-1" ? null : datalink.Members[0];
-                txtSTN2.Text = datalink.Members[1] == "-1" ? null : datalink.Members[1];
-                txtSTN3.Text = datalink.Members[2] == "-1" ? null : datalink.Members[2];
-                txtSTN4.Text = datalink.Members[3] == "-1" ? null : datalink.Members[3];
-                txtSTN5.Text = datalink.Members[4] == "-1" ? null : datalink.Members[4];
-                txtSTN6.Text = datalink.Members[5] == "-1" ? null : datalink.Members[5];
-                txtSTN7.Text = datalink.Members[6] == "-1" ? null : datalink.Members[6];
-                txtSTN8.Text = datalink.Members[7] == "-1" ? null : datalink.Members[7];
+                txtSTN1.Text = datalink.Members[0];
+                txtSTN2.Text = datalink.Members[1];
+                txtSTN3.Text = datalink.Members[2];
+                txtSTN4.Text = datalink.Members[3];
+                txtSTN5.Text = datalink.Members[4];
+                txtSTN6.Text = datalink.Members[5];
+                txtSTN7.Text = datalink.Members[6];
+                txtSTN8.Text = datalink.Members[7];
             }
 
             if (datalink.TDOAMembers != null)

--- a/dcs-dtc/New/Uploader/Aircrafts/F16/Systems/Datalink.cs
+++ b/dcs-dtc/New/Uploader/Aircrafts/F16/Systems/Datalink.cs
@@ -128,7 +128,7 @@ public partial class F16Uploader
 
     private Condition TDOA(string position, string status)
     {
-        return new Condition("FlightLead('" + position + "','" + status + "')");
+        return new Condition("TDOA('" + position + "','" + status + "')");
     }
 
     private CustomCommand EnableXMIT(string data)

--- a/dcs-dtc/New/Uploader/Aircrafts/F16/Systems/Datalink.cs
+++ b/dcs-dtc/New/Uploader/Aircrafts/F16/Systems/Datalink.cs
@@ -64,7 +64,7 @@ public partial class F16Uploader
                         tdoa = config.Datalink.TDOAMembers[i];
                     }
 
-                    if (member == "-1") continue;
+                    if (string.IsNullOrEmpty(member)) continue;
 
                     Cmd(UFC.DOWN);
                     Cmd(Digits(UFC, member.ToString()));

--- a/dcs-dtc/UI/Base/Controls/DTCNumericTextBox.cs
+++ b/dcs-dtc/UI/Base/Controls/DTCNumericTextBox.cs
@@ -26,7 +26,12 @@ namespace DTC.UI.Base.Controls
         public override string Text
         {
             get { return textBox.Text; }
-            set { textBox.Text = value; }
+            set
+            {
+                textBox.Text = value;
+                currentValue = string.IsNullOrEmpty(value) ? null
+                    : (decimal.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out var result) ? result : null);
+            }
         }
 
         public bool AllowFraction { get; set; } = false;

--- a/dcs-dtc/Utilities/Network/PresetDataSender.cs
+++ b/dcs-dtc/Utilities/Network/PresetDataSender.cs
@@ -13,7 +13,6 @@ internal class PresetDataSender
             using (var sw = new StreamWriter(ns))
             {
                 //System.Diagnostics.Debug.WriteLine(str);
-                File.WriteAllText(Path.Combine(Path.GetTempPath(), "dtc-last-command.lua"), str); // TEMP DEBUG - remove before PR
                 sw.WriteLine(str);
                 sw.Flush();
             }

--- a/dcs-dtc/Utilities/Network/PresetDataSender.cs
+++ b/dcs-dtc/Utilities/Network/PresetDataSender.cs
@@ -13,6 +13,7 @@ internal class PresetDataSender
             using (var sw = new StreamWriter(ns))
             {
                 //System.Diagnostics.Debug.WriteLine(str);
+                File.WriteAllText(Path.Combine(Path.GetTempPath(), "dtc-last-command.lua"), str); // TEMP DEBUG - remove before PR
                 sw.WriteLine(str);
                 sw.Flush();
             }


### PR DESCRIPTION
Fixes the F-16C Datalink STN upload to skip empty fields. 
If you wish to zero out or delete an existing STN field already
in the aircraft, use 0, a blank will now skip programing the slot.  

- Skip blank STN slots on upload instead of sending digit entry for
  ones the user never filled in. The uploader's blank check compared
  against a "-1" sentinel that the UI never actually produces (blank
  fields are "" or null), so it never skipped anything. A slot left
  truly blank now leaves whatever was already in the aircraft
  untouched; entering "0" still explicitly clears that slot, so both
  behaviors remain available.

- Fix DTCNumericTextBox failing to save a manually-cleared
  values. Setting .Text (e.g. loading a saved value from a preset)
  never updated the control's internal currentValue, so clearing a
  field that started with a value didn't fire the change
  notification - the box looked empty but the preset never updated.
  This affects any DTCNumericTextBox field app-wide, not just
  Datalink STN, and was blocking the STN fix above from being
  testable via the UI.

- Fix the TDOA per-member condition check calling the wrong Lua
  function. TDOA() built its condition as "FlightLead(...)" instead
  of "TDOA(...)", so uploads were calling
  DTC_F16C_CheckCondition_FlightLead (a 1-arg function) with 2 args
  instead of the existing DTC_F16C_CheckCondition_TDOA, meaning the
  D1 acknowledgment press was gated on the wrong condition.

Tested in-game against a preset with a mix of filled/blank STN slots:
upload now only cycles through the populated slots, clearing a slot
back to blank in the UI persists correctly, and the TDOA toggle
tracks the D1 press correctly.  Only tested with F16C. 
